### PR TITLE
fix url issue

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     if (decodedUser.exp < currentTime) {
       store.dispatch(logout());
-      window.location.href = '/login';
+      window.location.href = '/#/login';
     }
   } else {
     store = configureStore({});


### PR DESCRIPTION
I believe this pull request should repair the weird URL issue. What I think was happening was that, if your token had expired, we ran the line `window.location.href = '/login'` when it should have been `window.location.href = '/#/login'`.