### PR TITLE
fix search bar

### DIFF
--- a/frontend/src/components/hamburger_search/search_bar.jsx
+++ b/frontend/src/components/hamburger_search/search_bar.jsx
@@ -77,13 +77,15 @@ class SearchBar extends React.Component {
                 if (next > 0) {
                     next = document.getElementById(`results-${next}`);
                 } else {
-                    // next = document.getElementById(`results-${this.liCount}`);
                     next = document.getElementById("user-search");
                 }
                 next.focus();
             }
         } else if (e.key === "Escape") {
             this.props.closeSearch();
+        } else if (e.key === "Enter") {
+            this.props.closeSearch();
+            this.props.history.push(`/users/${e.target.innerText}`);
         }
     }
 

--- a/frontend/src/components/hamburger_search/search_bar_container.js
+++ b/frontend/src/components/hamburger_search/search_bar_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import SearchBar from "./search_bar";
 import { fetchSearchResults, clearSearchResults } from '../../actions/search_actions';
+import { withRouter } from 'react-router-dom';
 
 const mSTP = (state, ownProps) => ({
     results: state.entities.searchResults,
@@ -13,4 +14,4 @@ const mDTP = (dispatch) => ({
     clearSearchResults: () => dispatch(clearSearchResults),
 });
 
-export default connect(mSTP, mDTP)(SearchBar);
+export default withRouter(connect(mSTP, mDTP)(SearchBar));


### PR DESCRIPTION
Bad old version: If you pressed "Enter" while selecting someone's name, the searchbar remained open with "No results found" as their page was loading.

Good new version: If you press "Enter" while selecting someone's name, you go to their page with no issues!